### PR TITLE
Header-based authentication

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-curl "$INPUT_GOTIFY_API_BASE/message?token=$INPUT_GOTIFY_APP_TOKEN" \
+curl "$INPUT_GOTIFY_API_BASE/message" \
+	-H "X-Gotify-Key: $INPUT_GOTIFY_APP_TOKEN" \
 	-F "title=$INPUT_NOTIFICATION_TITLE" \
 	-F "message=$INPUT_NOTIFICATION_MESSAGE" \
 	-F "priority=$INPUT_NOTIFICATION_PRIORITY"


### PR DESCRIPTION
Hi @eikendev, thanks for this plugin.  
I have changed the authentication to use a header instead of the query parameter.

From a security perspective that is preferred, the URL should not contain sensitive information.  
The reason is that the URL can be spied by an attacker way easier than an authentication header.